### PR TITLE
Auto labeler

### DIFF
--- a/bin/non-qa-able-labeler
+++ b/bin/non-qa-able-labeler
@@ -53,3 +53,21 @@ apply_no_qa_label () {
     --data '{"labels": ["No QA"]}' \
     -S https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${CIRCLE_PR_NUMBER}
 }
+
+#######################################
+# Removes the No Qa label via the API
+#
+# Globals:
+#   GITHUB_OAUTH
+#   CIRCLE_PROJECT_USERNAME
+#   CIRCLE_PROJECT_REPONAME
+#   CIRCLE_PR_NUMBER
+#######################################
+remove_no_qa_label () {
+    echo "Removing No QA label"
+    curl -H "Authorization: token $GITHUB_OAUTH" \
+    -H "Accept: application/vnd.github.shadow-cat-preview+json" \
+    -H "Content-Type: application/json" \
+    --request DELETE \
+    -S https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${CIRCLE_PR_NUMBER}/labels/No%20QA
+}

--- a/bin/non-qa-able-labeler
+++ b/bin/non-qa-able-labeler
@@ -86,3 +86,18 @@ label_and_exit_if_repo_not_qa_able () {
     exit 0
   fi
 }
+
+#######################################
+# Checks the changes files in the PR
+# and exits if they are QA able
+#######################################
+remove_label_and_exit_if_files_are_qa_able () {
+  for file in "$(git diff --diff-filter=CMTRA --name-only origin/master...HEAD)"
+  do
+    if [[ ! -z "$(echo "$file" | grep -v '.feature\|features/\|tests/\|.md\|submodules\|.circleci')" ]]; then
+        echo "Some files are considered QA'able: $file"
+        remove_no_qa_label
+        exit 0
+    fi
+  done
+}

--- a/bin/non-qa-able-labeler
+++ b/bin/non-qa-able-labeler
@@ -34,3 +34,22 @@ non_qa_able_repos=(
   'Team-Standards-and-Procedures',
   'bitpay-api-microservice',
 )
+
+#######################################
+# Applies the No QA label to the PR
+#
+# Globals:
+#   GITHUB_OAUTH
+#   CIRCLE_PROJECT_USERNAME
+#   CIRCLE_PROJECT_REPONAME
+#   CIRCLE_PR_NUMBER
+#######################################
+apply_no_qa_label () {
+    echo "Applying No QA label"
+    curl -H "Authorization: token $GITHUB_OAUTH" \
+    -H "Accept: application/vnd.github.shadow-cat-preview+json" \
+    -H "Content-Type: application/json" \
+    --request POST \
+    --data '{"labels": ["No QA"]}' \
+    -S https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${CIRCLE_PR_NUMBER}
+}

--- a/bin/non-qa-able-labeler
+++ b/bin/non-qa-able-labeler
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# List of repositories considered not QA able
+non_qa_able_repos=(
+  'laravel-sodium',
+  'submodules',
+  'consultation-provider',
+  'gherking-cs-fixer',
+  'FlexibleMink',
+  'iLab-php-parser',
+  'phpunit-parallel-runner',
+  'spinify-php-client',
+  'medivo-client',
+  'BehatPaypalContext',
+  'behat-google-place-autocomplete',
+  'BehatFindALabContext',
+  'docker-hub',
+  'docker-php-cs-fixer',
+  'geo-location',
+  'iLab-php-client',
+  'PaymentProcessor',
+  'quest-client',
+  'Scripts',
+  'google-maps-mock-api',
+  'wheniwork-php-client',
+  'livechat-spinify-bridge',
+  'docker-ng-cli-karma',
+  'gae-stop-old-versions-orb',
+  'gae-prune-old-versions-orb',
+  '.github',
+  'IP-Phone-Provisioning',
+  'Team-Standards-and-Procedures',
+  'bitpay-api-microservice',
+)

--- a/bin/non-qa-able-labeler
+++ b/bin/non-qa-able-labeler
@@ -71,3 +71,18 @@ remove_no_qa_label () {
     --request DELETE \
     -S https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${CIRCLE_PR_NUMBER}/labels/No%20QA
 }
+
+#######################################
+# Labels the PR with no QA label then
+# exits
+#
+# Globals:
+#   non_qa_able_repos
+#   CIRCLE_PROJECT_REPONAME
+#######################################
+label_and_exit_if_repo_not_qa_able () {
+  if [[ " ${non_qa_able_repos[@]} " =~ "$CIRCLE_PROJECT_REPONAME" ]]; then
+    apply_no_qa_label
+    exit 0
+  fi
+}

--- a/bin/non-qa-able-labeler
+++ b/bin/non-qa-able-labeler
@@ -101,3 +101,9 @@ remove_label_and_exit_if_files_are_qa_able () {
     fi
   done
 }
+
+label_and_exit_if_repo_not_qa_able
+
+remove_label_and_exit_if_files_are_qa_able
+
+apply_no_qa_label


### PR DESCRIPTION
@aserv92 For: https://github.com/Medology/issues_coordinator/issues/405

This is a script to determine whether a PR has edited files that are considered Qa'able. In the event that nothing that can be tested is changed, this will apply a label 'No QA' which can be used by qa to identify that the PR can move along. This will also apply said label in the event it is in to a repo that is one of our standard non-qa'able repositories. 