### PR TITLE
Removing quotations to properly loop over files

### DIFF
--- a/bin/non-qa-able-labeler
+++ b/bin/non-qa-able-labeler
@@ -99,11 +99,16 @@ label_and_exit_if_repo_not_qa_able () {
 # and exits if they are QA able
 #######################################
 remove_label_and_exit_if_files_are_qa_able () {
-  for file in $(git diff --diff-filter=d --name-only origin/master...HEAD)
+  for file in $(git diff --name-only origin/master...HEAD)
   do
-
+    local non_comment_updates=""
     local qa_able_files="$(echo "$file" | grep -v '.feature\|features/\|tests/\|.md\|submodules\|.circleci')"
-    local non_comment_updates="$(git diff -w -G'(^[^\*# /])|(^#\w)|(^\s+[^\*#/])'  origin/master...HEAD $file)"
+
+    if [[ ! -f "$file" ]]; then
+       non_comment_updates="File was deleted"
+    else
+       non_comment_updates="$(git diff -w -G'(^[^\*# /])|(^#\w)|(^\s+[^\*#/])'  origin/master...HEAD $file)"
+    fi
 
     if [[ ! -z "$qa_able_files" && ! -z "$non_comment_updates" ]]; then
         echo ""

--- a/bin/non-qa-able-labeler
+++ b/bin/non-qa-able-labeler
@@ -99,7 +99,7 @@ label_and_exit_if_repo_not_qa_able () {
 # and exits if they are QA able
 #######################################
 remove_label_and_exit_if_files_are_qa_able () {
-  for file in "$(git diff --name-only origin/master...HEAD)"
+  for file in $(git diff --diff-filter=d --name-only origin/master...HEAD)
   do
 
     local qa_able_files="$(echo "$file" | grep -v '.feature\|features/\|tests/\|.md\|submodules\|.circleci')"

--- a/bin/non-qa-able-labeler
+++ b/bin/non-qa-able-labeler
@@ -99,6 +99,7 @@ label_and_exit_if_repo_not_qa_able () {
 # and exits if they are QA able
 #######################################
 remove_label_and_exit_if_files_are_qa_able () {
+  IFS=$'\n'
   for file in $(git diff --name-only origin/master...HEAD)
   do
     local non_comment_updates=""
@@ -110,15 +111,19 @@ remove_label_and_exit_if_files_are_qa_able () {
        non_comment_updates="$(git diff -w -G'(^[^\*# /])|(^#\w)|(^\s+[^\*#/])'  origin/master...HEAD $file)"
     fi
 
+    echo "Checking file $file"
+
     if [[ ! -z "$qa_able_files" && ! -z "$non_comment_updates" ]]; then
         echo ""
-        echo "Some files are considered QA'able: $file"
+        echo "Removing QA label due to: "
         echo "$non_comment_updates"
         echo ""
         remove_no_qa_label_if_exists
+        unset IFS
         exit 0
     fi
   done
+  unset IFS
 }
 
 label_and_exit_if_repo_not_qa_able


### PR DESCRIPTION
This fixes an issue where it cannot diff deleted files. It was also checking the diff for all files at once, which is why the quotations are removed so it can loop properly. 