### PR TITLE
Fix the problem that file with "git mv" is not recognized in the new location

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -30,7 +30,7 @@ if [[ "${CI:-}" == true ]] ; then
   remote="origin/master"
 fi
 
-staged_files=$(git status --short | grep '^[MARC]' | awk '{print $2}')
+staged_files=$(git status --short | grep '^[MARC]' | awk -F " " '{print $NF}')
 
 files=$(get_fixable_files "$staged_files")
 


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/11089

### Issue
When files are moved in commit history like:
```
R  features/api/findalab/twilio_fax2.feature -> features/api/twilio_fax2.feature
```
The precommit script is not extract the last part `features/api/twilio_fax2.feature` as the file that should be processed, but extracted the first part. This cause the linter fail since the first part doesn't exist anymore

### Fix
* Updated the script so extract the correct part