### PR TITLE
Stop attempting to fix non fixable files

### DIFF
--- a/bin/ci-style-fixer
+++ b/bin/ci-style-fixer
@@ -80,11 +80,30 @@ exit_if_on_master () {
     fi
 }
 
+#######################################
+# Filter fixable files
+#######################################
+get_fixable_files () {
+    local files=$1
+    fixable_files=""
+
+    for file in $files
+    do
+      if echo "$file" | grep 'css\|scss\|html\|js\|php\|feature'; then
+        fixable_files="$fixable_files $file"
+      fi
+    done
+    echo "$fixable_files"
+}
+
+
 
 exit_if_on_master
 
-if [[ ! -z "$files" ]];then
-    fix_and_stage_styles "$files"
+fixable_files=$(get_fixable_files "$files")
+
+if [[ ! -z "$fixable_files" ]];then
+    fix_and_stage_styles "$fixable_files"
 fi
 
 exit_if_no_changes

--- a/bin/ci-style-fixer
+++ b/bin/ci-style-fixer
@@ -94,8 +94,6 @@ get_fixable_files () {
     echo "$fixable_files"
 }
 
-
-
 exit_if_on_master
 
 fixable_files=$(get_fixable_files)

--- a/bin/ci-style-fixer
+++ b/bin/ci-style-fixer
@@ -3,7 +3,6 @@
 set -eu
 
 root=$(dirname "$0")
-files="$(git diff --diff-filter=CMTRA --name-only origin/master...HEAD)"
 
 #######################################
 # Set the git branch and tracker to that of the pull request
@@ -84,9 +83,8 @@ exit_if_on_master () {
 # Filter fixable files
 #######################################
 get_fixable_files () {
-    local files=$1
+    files="$(git diff --diff-filter=CMTRA --name-only origin/master...HEAD)"
     fixable_files=""
-
     for file in $files
     do
       if echo "$file" | grep 'css\|scss\|html\|js\|php\|feature'; then
@@ -100,7 +98,7 @@ get_fixable_files () {
 
 exit_if_on_master
 
-fixable_files=$(get_fixable_files "$files")
+fixable_files=$(get_fixable_files)
 
 if [[ ! -z "$fixable_files" ]];then
     fix_and_stage_styles "$fixable_files"


### PR DESCRIPTION
For #32 

**Method:**
Add PR adding a document like a PDF file 

**Expected Behavior:**
The CI build should pass.

**Actual Result:**
The CI fails on the cs-style-fixer step.

**Cause:**
The local method uses a pre-commit hook and validates all the changes in the PR.
The CI method also generates a PR in case fixes can be applied.

The CI script attempts to fix all the files in the PR. A PDF and many other documents are not _fixable_, the hook include that validation.


**Solution:**
Filter the fixable files before attempting to fix it.

**Customer Impact (for #releasenotes):**
N/A

**QA Notes (How to set up system for manual testing)**
N/A
