### PR TITLE
Remove colon from device path

### DIFF
--- a/lib/setup_nfs_functions.sh
+++ b/lib/setup_nfs_functions.sh
@@ -97,7 +97,7 @@ recreateVolumeIfMountFromDifferentFolder() {
   local volume_path=$2
   local volume_type=$3
   local volume_opts=$4
-  if [[ $(docker volume inspect --format '{{.Options.device}}' ${volume_name} | sed 's/://g') != "${volume_path}" ]]; then
+  if [[ $(docker volume inspect --format '{{.Options.device}}' ${volume_name} | sed 's/^://') != "${volume_path}" ]]; then
     docker volume rm "${volume_name}"
     createDockerVolume "${volume_name}" "${volume_path}" "${volume_type}" "${volume_opts}"
   fi

--- a/lib/setup_nfs_functions.sh
+++ b/lib/setup_nfs_functions.sh
@@ -97,7 +97,7 @@ recreateVolumeIfMountFromDifferentFolder() {
   local volume_path=$2
   local volume_type=$3
   local volume_opts=$4
-  if [[ $(docker volume inspect --format '{{.Options.device}}' ${volume_name}) != ":${volume_path}" ]]; then
+  if [[ $(docker volume inspect --format '{{.Options.device}}' ${volume_name} | sed 's/://g') != "${volume_path}" ]]; then
     docker volume rm "${volume_name}"
     createDockerVolume "${volume_name}" "${volume_path}" "${volume_type}" "${volume_opts}"
   fi


### PR DESCRIPTION
For https://github.com/Medology/ng-findalab/issues/3

### Issue
`docker volume inspect --format '{{.Options.device}}'` will return the path for the device with or w/o the colon on different operation system, which break this part of code that detect if the volume is already mount.
#### Result on Mac
```
docker volume inspect ng-findalab_project
[
    {
        "CreatedAt": "2020-10-06T18:00:01Z",
        "Driver": "local",
        "Labels": {},
        "Mountpoint": "/var/lib/docker/volumes/ng-findalab_project/_data",
        "Name": "ng-findalab_project",
        "Options": {
            "device": ":/Users/johnnie/Projects/ng-findalab",
            "o": "addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3",
            "type": "nfs"
        },
Remove colon from device path
        "Scope": "local"
    }
]
```
#### Result on Ubuntu
```
 docker volume inspect  ng-findalab_project
[
    {
        "CreatedAt": "2020-10-06T17:45:03Z",
        "Driver": "local",
        "Labels": {},
        "Mountpoint": "/var/lib/docker/volumes/ng-findalab_project/_data",
        "Name": "ng-findalab_project",
        "Options": {
            "device": "/home/johnnie/Projects/ng-findalab",
            "o": "bind",
            "type": "none"
        },
        "Scope": "local"
    }
]
```

So the script is updated that the colon will be removed from the result by default. By doing this, we can remove the colon from the condition `":${volume_path}" ` -> `"${volume_path}"`. On both OS we will compare path without colon.