### PR TITLE
Disable prompts when create hooks symlink on CI

### DIFF
--- a/bin/init_git_hooks
+++ b/bin/init_git_hooks
@@ -44,7 +44,9 @@ if [[ -L "$hooks" ]]; then
   if [[ `readlink "$hooks"` == ../hooks ]]; then
     echo "Symbolic link is configured correctly."
   else
-    exit_if_not_willing_to_remove_dir
+    if [[ "${CI:-}" != true ]] ; then
+        exit_if_not_willing_to_remove_dir
+    fi
     echo "Removing..."
     rm "$hooks"
 
@@ -53,7 +55,9 @@ if [[ -L "$hooks" ]]; then
 else
   echo "Git hooks symbolic link is not in place."
   if [[ -e "$hooks" ]]; then
-    exit_if_not_willing_to_remove_dir
+    if [[ "${CI:-}" != true ]] ; then
+        exit_if_not_willing_to_remove_dir
+    fi
     rm -rf "$hooks"
   fi
 


### PR DESCRIPTION
For https://github.com/Medology/www.healthlabs.com/issues/1443

On Circle CI, the `.git/hooks` folder exists and have some sample file in that, so we need to be able to remove the folder without user intervention.
```
circleci@default-b5830c78-b0e5-4517-bb95-d241599a478e:/tmp/healthlabs.com/.git/hooks$ ls -l
total 48
-rwxrwxr-x 1 circleci circleci  478 Oct 15 00:35 applypatch-msg.sample
-rwxrwxr-x 1 circleci circleci  896 Oct 15 00:35 commit-msg.sample
-rwxrwxr-x 1 circleci circleci 3327 Oct 15 00:35 fsmonitor-watchman.sample
-rwxrwxr-x 1 circleci circleci  189 Oct 15 00:35 post-update.sample
-rwxrwxr-x 1 circleci circleci  424 Oct 15 00:35 pre-applypatch.sample
-rwxrwxr-x 1 circleci circleci 1638 Oct 15 00:35 pre-commit.sample
-rwxrwxr-x 1 circleci circleci 1492 Oct 15 00:35 prepare-commit-msg.sample
-rwxrwxr-x 1 circleci circleci 1348 Oct 15 00:35 pre-push.sample
-rwxrwxr-x 1 circleci circleci 4898 Oct 15 00:35 pre-rebase.sample
-rwxrwxr-x 1 circleci circleci  544 Oct 15 00:35 pre-receive.sample
-rwxrwxr-x 1 circleci circleci 3610 Oct 15 00:35 update.sample
```