### PR TITLE
Auto-remove PHP-CS-fixer container after run

### DIFF
--- a/bin/php-cs-fixer
+++ b/bin/php-cs-fixer
@@ -13,5 +13,6 @@ docker run \
     ${TTY} \
     -i \
     -v $(pwd):/workdir:delegated \
+    --rm \
     ${PHP_CS_FIXER_IMAGE} \
     fix "$@"


### PR DESCRIPTION
**Method:**
1. Make a non-standards complaint change
2. Add it to a commit

**Expected Behavior:**
The docker command should clean up after itself since it is a pre-commit hook

**Actual Result:**
php-cs-fixer docker command hangs out

**Cause:**
docker command being run without cleaning itself up after completion.

**Solution:**
Add `--rm` to command

For #42


