### PR TITLE
Fix set -o and remove gsed since colored output is disabled in composer 2.0

### DIFF
--- a/bin/install_composer
+++ b/bin/install_composer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu -o pipefail
+set -euo pipefail
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 

--- a/bin/install_composer
+++ b/bin/install_composer
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
 
-set -euo -pipefail
+set -eu -o pipefail
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 EXPECTED_VERSION=2.0.8
 EXPECTED_CHECKSUM=608432e9a850f02b527a661e6771546a10a8cc16e17363754c101f06d1ab03e53106d7aef2b5faa606d67523fcf33dc3
 
-# Check for existing installation
+# Check for existing installation.
 if [ -e "$ROOT"/bin/composer ]; then
     echo "Checking Composer version..."
     FOUND_VERSION=$( \
         cd "$ROOT" && ./bin/composer --version | \
         tail -1 | \
-        awk '{print $3}' | \
-        "$ROOT"/bin/linux-sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" \
+        awk '{print $3}' \
     )
 
     # Check version of installed composer


### PR DESCRIPTION
For https://github.com/Medology/www.healthlabs.com/issues/1400

This PR will fix the following for `install_composer` script
* `set -euo -pipefail` should be `set -eu -o pipfail`
* `gsed` is not needed anymore since composer output has no color since 2.0