### PR TITLE
Fix short tag and alt syntax

### DIFF
--- a/config/.php_cs.dist
+++ b/config/.php_cs.dist
@@ -7,23 +7,30 @@ return PhpCsFixer\Config::create()
         '@Symfony'               => true,
         'binary_operator_spaces' => [
             'operators' => [
-            '=>' => 'align_single_space_minimal',
-        ], ],
+                '=>' => 'align_single_space_minimal',
+            ],
+        ],
         'echo_tag_syntax'             => false,
         'ordered_class_elements'      => true,
         'ordered_imports'             => true,
         'yoda_style'                  => false,
         'blank_line_before_statement' => true,
         'class_attributes_separation' => [
-            'elements' => ['const', 'method', 'property'],
+            'elements' => [
+                'const',
+                'method',
+                'property'
+            ],
         ],
         'no_alternative_syntax'  => false,
         'phpdoc_no_empty_return' => true,
-        'concat_space'           => ['spacing' => 'one'],
+        'concat_space'           => [
+            'spacing' => 'one'
+        ],
         'phpdoc_no_alias_tag'    => [
-                        'type' => 'var',
-                        'link' => 'see',
-                    ],
-	      'single_line_throw'      => false
+            'type' => 'var',
+            'link' => 'see',
+        ],
+        'single_line_throw'      => false
     ])
     ->setFinder($finder)->setUsingCache(false);

--- a/config/.php_cs.dist
+++ b/config/.php_cs.dist
@@ -9,6 +9,7 @@ return PhpCsFixer\Config::create()
             'operators' => [
             '=>' => 'align_single_space_minimal',
         ], ],
+        'echo_tag_syntax'             => false,
         'ordered_class_elements'      => true,
         'ordered_imports'             => true,
         'yoda_style'                  => false,
@@ -16,6 +17,7 @@ return PhpCsFixer\Config::create()
         'class_attributes_separation' => [
             'elements' => ['const', 'method', 'property'],
         ],
+        'no_alternative_syntax'  => false,
         'phpdoc_no_empty_return' => true,
         'concat_space'           => ['spacing' => 'one'],
         'phpdoc_no_alias_tag'    => [


### PR DESCRIPTION
Style fixer is removing the PHP short echo tags, and alternate syntax. This happened in this recent PR https://github.com/Medology/stdcheck.com/pull/12204/files#diff-3e45f0a722f132572c5e89a2ba90fa9cc59fd505c4d796050698e3d1acb2b3da.

This should not occur, as although we almost never use PHP code in an HTML template, when we do, our coding standards require that we use this syntax.