### PR TITLE
Remove TTY for GCloud

### DIFF
--- a/bin/google-cloud-sdk
+++ b/bin/google-cloud-sdk
@@ -5,14 +5,13 @@ set -euo pipefail
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
-. ${dir}/get_tty
 . ${dir}/get_local_user
 . ${dir}/get_images
 . "$ROOT"/docker/lib/volumes.sh
 
 docker run \
     ${LOCAL_USER_ID:-} \
-    -i$TTY \
+    -i \
     --rm \
     --mount source=$PROJECT_VOLUME,target=/workdir \
     --mount source=user_config,target=/home/user/.config \


### PR DESCRIPTION
Remove TTY fro Gcloud, same reason as https://github.com/Medology/stdcheck.com/commit/f6bf4d65418a63305467330265bf1589a36d8680